### PR TITLE
Using updated ValidationResult object [SUBS-535]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# validator-coordinator
+# Validator Coordinator
+[![Build Status](https://travis-ci.org/EMBL-EBI-SUBS/validator-coordinator.svg?branch=master)](https://travis-ci.org/EMBL-EBI-SUBS/validator-coordinator)
+
 This repository contains the entry points of the validation pipeline.
 
 **TODO** Add the various entry points

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,11 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-    maven { url 'https://jitpack.io' } // FIXME - remove
 }
 
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'https://jitpack.io' } // FIXME - remove
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.1.RELEASE")
@@ -27,8 +25,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
 
     compile("uk.ac.ebi.subs:subs-processing-model:1.0.0-SNAPSHOT")
-    //compile("uk.ac.ebi.subs:validator-common:1.8.0-SNAPSHOT") FIXME - temporary fix while the new validator-common version is not available
-    compile 'com.github.EMBL-EBI-SUBS:validator-common:SUBS-535-SNAPSHOT' // FIXME - remove
+    compile("uk.ac.ebi.subs:validator-common:1.8.0-SNAPSHOT")
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-version '1.0.1-SNAPSHOT'
+version '0.1.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
@@ -10,11 +10,13 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    maven { url 'https://jitpack.io' } // FIXME - remove
 }
 
 buildscript {
     repositories {
         mavenCentral()
+        maven { url 'https://jitpack.io' } // FIXME - remove
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.1.RELEASE")
@@ -25,7 +27,8 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
 
     compile("uk.ac.ebi.subs:subs-processing-model:1.0.0-SNAPSHOT")
-    compile("uk.ac.ebi.subs:validator-common:1.5.0-SNAPSHOT")
+    //compile("uk.ac.ebi.subs:validator-common:1.8.0-SNAPSHOT") FIXME - temporary fix while the new validator-common version is not available
+    compile 'com.github.EMBL-EBI-SUBS:validator-common:SUBS-535-SNAPSHOT' // FIXME - remove
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 }

--- a/src/main/java/uk/ac/ebi/subs/validator/coordinator/Coordinator.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/coordinator/Coordinator.java
@@ -64,11 +64,7 @@ public class Coordinator {
         ValidationMessageEnvelope<Sample> messageEnvelope = new ValidationMessageEnvelope<>(validationResult.getUuid(), sample);
 
         logger.debug("Sending sample to validation queues");
-
-        // TODO need to correct BioSamples and Taxon routing key names
-        rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_BIOSAMPLES_SAMPLE_CREATED, messageEnvelope);
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_ENA_SAMPLE_VALIDATION, messageEnvelope);
-        rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_TAXON_SAMPLE_CREATED, messageEnvelope);
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_CORE_SAMPLE_VALIDATION, messageEnvelope);
 
         return validationResult.getEntityUuid() != null;

--- a/src/main/java/uk/ac/ebi/subs/validator/util/BlankValidationResultMaps.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/util/BlankValidationResultMaps.java
@@ -1,7 +1,9 @@
 package uk.ac.ebi.subs.validator.util;
 
+import uk.ac.ebi.subs.validator.data.SingleValidationResult;
 import uk.ac.ebi.subs.validator.data.ValidationAuthor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -28,27 +30,27 @@ public class BlankValidationResultMaps {
      *
      * @return an initialised mapping from the required Validation service(ValidationAuthor) to it's respected validation result(boolean, false by default)
      */
-    public static Map<ValidationAuthor, Boolean> forSample() {
+    public static Map<ValidationAuthor, List<SingleValidationResult>> forSample() {
         return generateDefaultMap(SAMPLE_VALIDATION_SERVICES_REQUIRED);
     }
 
-    public static Map<ValidationAuthor, Boolean> forStudy() {
+    public static Map<ValidationAuthor, List<SingleValidationResult>> forStudy() {
         return generateDefaultMap(STUDY_VALIDATION_SERVICES_REQUIRED);
     }
 
-    public static Map<ValidationAuthor, Boolean> forAssay() {
+    public static Map<ValidationAuthor, List<SingleValidationResult>> forAssay() {
         return generateDefaultMap(ASSAY_VALIDATION_SERVICES_REQUIRED);
     }
 
-    public static Map<ValidationAuthor, Boolean> forAssayData() {
+    public static Map<ValidationAuthor, List<SingleValidationResult>> forAssayData() {
         return generateDefaultMap(ASSAY_DATA_VALIDATION_SERVICES_REQUIRED);
     }
 
-    private static Map<ValidationAuthor, Boolean> generateDefaultMap(List<ValidationAuthor> validationAuthors) {
-        Map<ValidationAuthor, Boolean> blankValidationResultMap = new HashMap<>();
+    private static Map<ValidationAuthor, List<SingleValidationResult>> generateDefaultMap(List<ValidationAuthor> validationAuthors) {
+        Map<ValidationAuthor, List<SingleValidationResult>> blankValidationResultMap = new HashMap<>();
 
         for(ValidationAuthor author: validationAuthors) {
-            blankValidationResultMap.put(author, false);
+            blankValidationResultMap.put(author, new ArrayList<>());
         }
 
         return blankValidationResultMap;


### PR DESCRIPTION
### Changes:
- README update.
- Corrected **BioSamples** and **Taxon** routing key names for sample validation requests.
- Using new `validator-common` with updated `ValidationResult` object.