### PR TITLE
[SUBS-568] Fix validator-coordinator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '0.1.0-SNAPSHOT'
+version '0.1.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
 
     compile("uk.ac.ebi.subs:subs-processing-model:1.0.0-SNAPSHOT")
-    compile("uk.ac.ebi.subs:validator-common:1.13.0-SNAPSHOT")
+    compile("uk.ac.ebi.subs:validator-common:1.13.1-SNAPSHOT")
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 }

--- a/src/main/java/uk/ac/ebi/subs/validator/coordinator/Coordinator.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/coordinator/Coordinator.java
@@ -63,6 +63,8 @@ public class Coordinator {
         logger.debug("Sending sample to validation queues");
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_ENA_SAMPLE_VALIDATION, messageEnvelope);
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_CORE_SAMPLE_VALIDATION, messageEnvelope);
+        rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_TAXON_SAMPLE_VALIDATION, messageEnvelope);
+        rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_BIOSAMPLES_SAMPLE_VALIDATION, messageEnvelope);
 
         return validationResult.getEntityUuid() != null;
     }

--- a/src/main/java/uk/ac/ebi/subs/validator/coordinator/Coordinator.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/coordinator/Coordinator.java
@@ -22,7 +22,6 @@ import uk.ac.ebi.subs.validator.messaging.RoutingKeys;
 public class Coordinator {
     private static final Logger logger = LoggerFactory.getLogger(Coordinator.class);
 
-    @Autowired
     private RabbitMessagingTemplate rabbitMessagingTemplate;
 
     @Autowired
@@ -40,16 +39,18 @@ public class Coordinator {
      * the UUID of the {@link ValidationResult}
      */
     @RabbitListener(queues = Queues.SUBMISSION_SAMPLE_VALIDATOR)
-    public boolean processSampleSubmission(SubmittableValidationEnvelope<Sample> envelope) {
+    public void processSampleSubmission(SubmittableValidationEnvelope<Sample> envelope) {
         Sample sample = envelope.getEntityToValidate();
 
         if (sample == null) {
             throw new IllegalArgumentException("The envelop should contain a sample.");
         }
 
-        logger.info("Received validation request on sample {}", sample.getId());
+        logger.info("Received validation request on sample with id {}", sample.getId());
 
-        return handleSample(sample, envelope.getSubmissionId());
+        if (!handleSample(sample, envelope.getSubmissionId())) {
+            logger.error("Error handling sample with id {}", sample.getId());
+        }
     }
 
     private boolean handleSample(Sample sample, String submissionId) {
@@ -57,8 +58,7 @@ public class Coordinator {
 
         logger.debug("Validation result document has been persisted into MongoDB with ID: {}", validationResult.getUuid());
 
-        ValidationMessageEnvelope<Sample> messageEnvelope =
-                new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), sample);
+        ValidationMessageEnvelope<Sample> messageEnvelope = new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), sample);
 
         logger.debug("Sending sample to validation queues");
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_ENA_SAMPLE_VALIDATION, messageEnvelope);
@@ -74,16 +74,18 @@ public class Coordinator {
      * the UUID of the {@link ValidationResult}
      */
     @RabbitListener(queues = Queues.SUBMISSION_STUDY_VALIDATOR)
-    public boolean processStudySubmission(SubmittableValidationEnvelope<Study> envelope){
+    public void processStudySubmission(SubmittableValidationEnvelope<Study> envelope){
         Study study = envelope.getEntityToValidate();
 
         if (study == null) {
             throw new IllegalArgumentException("The envelop should contain a study.");
         }
 
-        logger.info("Received validation request on study {}", study.getId());
+        logger.info("Received validation request on study with id {}", study.getId());
 
-        return handleStudy(study, envelope.getSubmissionId());
+        if (!handleStudy(study, envelope.getSubmissionId())) {
+            logger.error("Error handling study with id {}", study.getId());
+        }
     }
 
     private boolean handleStudy(Study study, String submissionId) {
@@ -91,8 +93,7 @@ public class Coordinator {
 
         logger.debug("Validation result document has been persisted into MongoDB with ID: {}", validationResult.getUuid());
 
-        ValidationMessageEnvelope<Study> messageEnvelope =
-                new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), study);
+        ValidationMessageEnvelope<Study> messageEnvelope = new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), study);
 
         logger.debug("Sending study to validation queues");
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_CORE_STUDY_VALIDATION, messageEnvelope);
@@ -108,7 +109,7 @@ public class Coordinator {
      * the UUID of the {@link ValidationResult}
      */
     @RabbitListener(queues = Queues.SUBMISSION_ASSAY_VALIDATOR)
-    public boolean processAssaySubmission(SubmittableValidationEnvelope<Assay> envelope) {
+    public void processAssaySubmission(SubmittableValidationEnvelope<Assay> envelope) {
         Assay assay = envelope.getEntityToValidate();
 
         if (assay == null) {
@@ -117,7 +118,9 @@ public class Coordinator {
 
         logger.info("Received validation request on assay {}", assay.getId());
 
-        return handleAssay(assay, envelope.getSubmissionId());
+        if (!handleAssay(assay, envelope.getSubmissionId())) {
+            logger.error("Error handling assay with id {}", assay.getId());
+        }
     }
 
     private boolean handleAssay(Assay assay, String submissionId) {
@@ -125,8 +128,7 @@ public class Coordinator {
 
         logger.debug("Validation result document has been persisted into MongoDB with ID: {}", validationResult.getUuid());
 
-        ValidationMessageEnvelope<Assay> messageEnvelope =
-                new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), assay);
+        ValidationMessageEnvelope<Assay> messageEnvelope = new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), assay);
 
         logger.debug("Sending assay to validation queues");
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_CORE_ASSAY_VALIDATION, messageEnvelope);
@@ -142,7 +144,7 @@ public class Coordinator {
      * the UUID of the {@link ValidationResult}
      */
     @RabbitListener(queues = Queues.SUBMISSION_ASSAY_DATA_VALIDATOR)
-    public boolean processAssayDataSubmission(SubmittableValidationEnvelope<AssayData> envelope) {
+    public void processAssayDataSubmission(SubmittableValidationEnvelope<AssayData> envelope) {
         AssayData assayData = envelope.getEntityToValidate();
 
         if (assayData == null) {
@@ -151,7 +153,9 @@ public class Coordinator {
 
         logger.info("Received validation request on assay data {}", assayData.getId());
 
-        return handleAssayData(assayData, envelope.getSubmissionId());
+        if (!handleAssayData(assayData, envelope.getSubmissionId())) {
+            logger.error("Error handling assayData with id {}", assayData.getId());
+        }
     }
 
     private boolean handleAssayData(AssayData assayData, String submissionId) {
@@ -159,8 +163,7 @@ public class Coordinator {
 
         logger.debug("Validation result document has been persisted into MongoDB with ID: {}", validationResult.getUuid());
 
-        ValidationMessageEnvelope<AssayData> messageEnvelope =
-                new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), assayData);
+        ValidationMessageEnvelope<AssayData> messageEnvelope = new ValidationMessageEnvelope<>(validationResult.getUuid(), validationResult.getVersion(), assayData);
 
         logger.debug("Sending assay data to validation queues");
         rabbitMessagingTemplate.convertAndSend(Exchanges.VALIDATION, RoutingKeys.EVENT_CORE_ASSAYDATA_VALIDATION, messageEnvelope);

--- a/src/main/java/uk/ac/ebi/subs/validator/messaging/CoordinatorMessagingConfiguration.java
+++ b/src/main/java/uk/ac/ebi/subs/validator/messaging/CoordinatorMessagingConfiguration.java
@@ -4,11 +4,10 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.converter.MessageConverter;
 
 /**
  * Created by karoly on 05/07/2017.
@@ -18,8 +17,8 @@ import org.springframework.messaging.converter.MessageConverter;
 public class CoordinatorMessagingConfiguration {
 
     @Bean
-    public MessageConverter messageConverter() {
-        return new MappingJackson2MessageConverter();
+    public Jackson2JsonMessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 
     /**

--- a/src/test/java/uk/ac/ebi/subs/validator/coordinator/CoordinatorTest.java
+++ b/src/test/java/uk/ac/ebi/subs/validator/coordinator/CoordinatorTest.java
@@ -1,6 +1,5 @@
 package uk.ac.ebi.subs.validator.coordinator;
 
-import uk.ac.ebi.subs.validator.coordinator.config.RabbitMQDependentTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -13,14 +12,11 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.subs.data.component.Team;
 import uk.ac.ebi.subs.data.submittable.Sample;
+import uk.ac.ebi.subs.validator.coordinator.config.RabbitMQDependentTest;
 import uk.ac.ebi.subs.validator.data.SubmittableValidationEnvelope;
 import uk.ac.ebi.subs.validator.repository.ValidationResultRepository;
 
 import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Created by karoly on 30/05/2017.
@@ -31,9 +27,6 @@ import static org.junit.Assert.assertThat;
 @Category(RabbitMQDependentTest.class)
 @SpringBootTest("uk.ac.ebi.subs.validator")
 public class CoordinatorTest {
-
-    @Autowired
-    ValidationResultRepository repository;
 
     @Autowired
     private Coordinator coordinator;
@@ -57,7 +50,7 @@ public class CoordinatorTest {
     public void testSubmissionWithSample() {
         SubmittableValidationEnvelope<Sample> submittableValidationEnvelope = createSubmittableEnvelopeWithSample();
 
-        assertThat(coordinator.processSampleSubmission(submittableValidationEnvelope), is(equalTo(true)));
+        coordinator.processSampleSubmission(submittableValidationEnvelope);
     }
 
     private SubmittableValidationEnvelope createSubmittableEnvelopeWithoutSample() {


### PR DESCRIPTION
- Using `Jackson2JsonMessageConverter`
- `Coordinator.process<Submittable>Submission()` with void return type
- `Coordinator.processSampleSubmission()` sends validation requests to:
  - Core Validator
  - ENA Validator
  - Taxon Validator
  - Biosamples Validator